### PR TITLE
Fix for Apple Elementary Stream Descriptor atoms

### DIFF
--- a/src/TaglibSharp/Mpeg4/Boxes/AppleElementaryStreamDescriptor.cs
+++ b/src/TaglibSharp/Mpeg4/Boxes/AppleElementaryStreamDescriptor.cs
@@ -3,10 +3,11 @@
 // ItemListBox.
 //
 // Author:
-//   Brian Nickel (brian.nickel@gmail.com)
+//  Brian Nickel (brian.nickel@gmail.com)
+//  RBoy1
 //
 // Copyright (C) 2006-2007 Brian Nickel
-// 
+//
 // This library is free software; you can redistribute it and/or modify
 // it  under the terms of the GNU Lesser General Public License version
 // 2.1 as published by the Free Software Foundation.
@@ -40,14 +41,140 @@ namespace TagLib.Mpeg4
 #region Private Fields
 
         /// <summary>
+        /// Descriptor Tags
+        /// </summary>
+        private enum DescriptorTag
+        {
+            Forbidden_00 = 0,
+            ObjectDescrTag = 1,
+            InitialObjectDescrTag = 2,
+            ES_DescrTag = 3,
+            DecoderConfigDescrTag = 4,
+            DecSpecificInfoTag = 5,
+            SLConfigDescrTag = 6,
+            ContentIdentDescrTag = 7,
+            SupplContentIdentDescrTag = 8,
+            IPI_DescrPointerTag = 9,
+            IPMP_DescrPointerTag = 10,
+            IPMP_DescrTag = 11,
+            QoS_DescrTag = 12,
+            RegistrationDescrTag = 13,
+            ES_ID_IncTag = 14,
+            ES_ID_RefTag = 15,
+            MP4_IOD_Tag = 16,
+            MP4_OD_Tag = 17,
+            IPL_DescrPointerRefTag = 18,
+            ExtensionProfileLevelDescrTag = 19,
+            profileLevelIndicationIndexDescrTag = 20,
+            ReservedForFutureISOUse_15_TO_3F = 21,
+            ContentClassificationDescrTag = 64,
+            KeyWordDescrTag = 65,
+            RatingDescrTag = 66,
+            LanguageDescrTag = 67,
+            ShortTextualDescrTag = 68,
+            ExpandedTextualDescrTag = 69,
+            ContentCreatorNameDescrTag = 70,
+            ContentCreationDateDescrTag = 71,
+            OCICreatorNameDescrTag = 72,
+            OCICreationDateDescrTag = 73,
+            SmpteCameraPositionDescrTag = 74,
+            SegmentDescrTag = 75,
+            MediaTimeDescrTag = 76,
+            ReservedForFutureISOUseOCI = 77,
+            IPMP_ToolsListDescrTag = 96,
+            IPMP_ToolTag = 97,
+            M4MuxTimingDescrTag = 98,
+            M4MuxCodeTableDescrTag = 99,
+            ExtSLConfigDescrTag = 100,
+            M4MuxBufferSizeDescrTag = 101,
+            M4MuxIdentDescrTag = 102,
+            DependencyPointerTag = 103,
+            DependencyMarkerTag = 104,
+            M4MuxChannelDescrTag = 105,
+            ReservedForFutureISO_6A_TO_BF = 106,
+            UserPrivate = 192,
+            Forbidden_FF = 255,
+        }
+
+        /// <summary>
+        /// Contains the stream ID.
+        /// </summary>
+        private ushort es_id;
+
+        /// <summary>
+        /// the ES_ID of another elementary stream on which this elementary stream depends
+        /// </summary>
+        private ushort dependsOn_ES_ID;
+
+        /// <summary>
+        /// Indicates that a dependsOn_ES_ID will follow
+        /// </summary>
+        private bool stream_dependence_flag;
+
+        /// <summary>
+        /// OCR Stream Flag
+        /// </summary>
+        private bool ocr_stream_flag;
+
+        /// <summary>
+        /// OCR ES_ID
+        /// </summary>
+        private ushort OCR_ES_Id;
+
+        /// <summary>
+        /// Indicates that a URLstring will follow
+        /// </summary>
+        private bool URL_flag;
+
+        /// <summary>
+        /// Length of URL String
+        /// </summary>
+        private byte URLlength;
+
+        /// <summary>
+        /// URL String of URLlength, contains a URL that shall point to the location of an SL-packetized stream by name
+        /// </summary>
+        private string URLstring;
+
+        /// <summary>
+        ///    Contains the stream priority.
+        /// </summary>
+        private byte stream_priority;
+
+        /// <summary>
+        ///    Contains the object type ID.
+        /// </summary>
+        private byte object_type_id;
+
+        /// <summary>
+        ///    Contains the stream type.
+        /// </summary>
+        private byte stream_type;
+
+        /// <summary>
+        /// Indicates that this stream is used for upstream information
+        /// </summary>
+        private bool upStream;
+
+        /// <summary>
+        ///    Contains the bugger size.
+        /// </summary>
+        private uint buffer_size_db;
+
+        /// <summary>
         ///    Contains the maximum bitrate.
         /// </summary>
-        readonly uint max_bitrate;
+        private uint max_bitrate;
 
         /// <summary>
         ///    Contains the average bitrate.
         /// </summary>
-        readonly uint average_bitrate;
+        private uint average_bitrate;
+
+        /// <summary>
+        ///    Contains the decoder config.
+        /// </summary>
+        private ByteVector decoder_config;
 
 #endregion
 
@@ -79,59 +206,142 @@ namespace TagLib.Mpeg4
         /// <exception cref="CorruptFileException">
         ///    Valid data could not be read.
         /// </exception>
-        public AppleElementaryStreamDescriptor (BoxHeader header, TagLib.File file, IsoHandlerBox handler)
-        : base (header, file, handler)
+        public AppleElementaryStreamDescriptor(BoxHeader header,
+                                               TagLib.File file,
+                                               IsoHandlerBox handler)
+        : base(header, file, handler)
         {
+            /* ES_Descriptor Specifications
+             *  Section 7.2.6.5 http://ecee.colorado.edu/~ecen5653/ecen5653/papers/ISO%2014496-1%202004.PDF
+             */
+
+            ByteVector box_data = file.ReadBlock(DataSize);
+            decoder_config = new ByteVector();
             int offset = 0;
-            ByteVector box_data = file.ReadBlock (DataSize);
-            DecoderConfig = new ByteVector ();
 
             // Elementary Stream Descriptor Tag
-            if (box_data[offset++] == 3) {
-                // We have a descriptor tag. Check that it's at
-                // least 20 long.
-                if (ReadLength (box_data, ref offset) < 20)
-                    throw new CorruptFileException ("Insufficient data present.");
+            if ((DescriptorTag)box_data[offset++] != DescriptorTag.ES_DescrTag)
+                throw new CorruptFileException("Invalid Elementary Stream Descriptor, missing tag.");
 
-                StreamId = box_data.Mid (offset, 2).ToUShort ();
-                offset += 2;
-                StreamPriority = box_data[offset++];
-            } else {
-                // The tag wasn't found, so the next two byte
-                // are the ID, and after that, business as
-                // usual.
-                StreamId = box_data.Mid (offset, 2).ToUShort ();
-                offset += 2;
+            // We have a descriptor tag. Check that the remainder of the tag is at least [Base (3 bytes) + DecoderConfigDescriptor (15 bytes) + SLConfigDescriptor (3 bytes) + OtherDescriptors] bytes long
+            uint es_length = ReadLength(box_data, ref offset);
+            uint min_es_length = 3 + 15 + 3; // Base minimum length
+            if (es_length < min_es_length)
+                throw new CorruptFileException("Insufficient data present.");
+
+            es_id = box_data.Mid(offset, 2).ToUShort();
+            offset += 2; // Done with ES_ID
+
+            stream_dependence_flag = ((byte)((box_data[offset] >> 7) & 0x1) == 0x1 ? true : false); // 1st bit
+            URL_flag = ((byte)((box_data[offset] >> 6) & 0x1) == 0x1 ? true : false); // 2nd bit
+            ocr_stream_flag = ((byte)((box_data[offset] >> 5) & 0x1) == 0x1 ? true : false); // 3rd bit
+            stream_priority = (byte)(box_data[offset++] & 0x1F); // Last 5 bits and we're done with this byte
+
+            if (stream_dependence_flag)
+            {
+                min_es_length += 2; // We need 2 more bytes
+                if (es_length < min_es_length)
+                    throw new CorruptFileException("Insufficient data present.");
+
+                dependsOn_ES_ID = box_data.Mid(offset, 2).ToUShort();
+                offset += 2; // Done with stream dependence
             }
 
-            // Verify that the next data is the Decoder
-            // Configuration Descriptor Tag and escape if it won't
-            // work out.
-            if (box_data[offset++] != 4)
-                throw new CorruptFileException ("Could not identify decoder configuration descriptor.");
+            if (URL_flag)
+            {
+                min_es_length += 2; // We need 1 more byte
+                if (es_length < min_es_length)
+                    throw new CorruptFileException("Insufficient data present.");
 
-            // Check that it's at least 15 long.
-            if (ReadLength (box_data, ref offset) < 15)
-                throw new CorruptFileException ("Could not read data. Too small.");
+                URLlength = box_data[offset++]; // URL Length
+                min_es_length += URLlength; // We need URLength more bytes
+                if (es_length < min_es_length)
+                    throw new CorruptFileException("Insufficient data present.");
 
-            // Read a lot of good info.
-            ObjectTypeId = box_data[offset++];
-            StreamType = box_data[offset++];
-            BufferSizeDB = box_data.Mid (offset, 3).ToUInt ();
-            offset += 3;
-            max_bitrate = box_data.Mid (offset, 4).ToUInt ();
-            offset += 4;
-            average_bitrate = box_data.Mid (offset, 4).ToUInt ();
-            offset += 4;
+                URLstring = box_data.Mid(offset, URLlength).ToString(); // URL name
+                offset += URLlength; // Done with URL name
+            }
 
-            // Verify that the next data is the Decoder Specific
-            // Descriptor Tag and escape if it won't work out.
-            if (box_data[offset++] != 5)
-                throw new CorruptFileException ("Could not identify decoder specific descriptor.");
+            if (ocr_stream_flag)
+            {
+                min_es_length += 2; // We need 2 more bytes
+                if (es_length < min_es_length)
+                    throw new CorruptFileException("Insufficient data present.");
 
-            // The rest of the info is decoder specific.
-            uint length = ReadLength (box_data, ref offset);
-            DecoderConfig = box_data.Mid (offset, (int)length);
+                OCR_ES_Id = box_data.Mid(offset, 2).ToUShort();
+                offset += 2; // Done with OCR
+            }
+
+            while (offset < DataSize) // Loop through all trailing Descriptors Tags
+            {
+                DescriptorTag tag = (DescriptorTag)box_data[offset++];
+                switch (tag)
+                {
+                    case DescriptorTag.DecoderConfigDescrTag: // DecoderConfigDescriptor
+                    {
+                        // Check that the remainder of the tag is at least 13 bytes long (13 + DecoderSpecificInfo[] + profileLevelIndicationIndexDescriptor[])
+                        if (ReadLength(box_data, ref offset) < 13)
+                            throw new CorruptFileException("Could not read data. Too small.");
+
+                        // Read a lot of good info.
+                        object_type_id = box_data[offset++];
+
+                        stream_type = (byte)(box_data[offset] >> 2); // First 6 bits
+                        upStream = ((byte)((box_data[offset++] >> 1) & 0x1) == 0x1 ? true : false); // 7th bit and we're done with the stream bits
+
+                        buffer_size_db = box_data.Mid(offset, 3).ToUInt();
+                        offset += 3; // Done with bufferSizeDB
+
+                        max_bitrate = box_data.Mid(offset, 4).ToUInt();
+                        offset += 4; // Done with maxBitrate
+
+                        average_bitrate = box_data.Mid(offset, 4).ToUInt();
+                        offset += 4; // Done with avgBitrate
+
+                        // If there's a DecoderSpecificInfo[] array at the end it'll pick it up in the while loop
+                    }
+                    break;
+
+                    case DescriptorTag.DecSpecificInfoTag: // DecoderSpecificInfo
+                    {
+                        // The rest of the info is decoder specific.
+                        uint length = ReadLength(box_data, ref offset);
+
+                        decoder_config = box_data.Mid(offset, (int)length);
+                        offset += (int)length; // We're done with the config
+                    }
+                    break;
+
+
+                    case DescriptorTag.SLConfigDescrTag: // SLConfigDescriptor
+                    {
+                        // The rest of the info is SL specific.
+                        uint length = ReadLength(box_data, ref offset);
+
+                        offset += (int)length; // Skip the rest of the descriptor as reported in the length so we can move onto the next one
+                    }
+                    break;
+
+                    case DescriptorTag.Forbidden_00:
+                    case DescriptorTag.Forbidden_FF:
+                        throw new CorruptFileException("Invalid Descriptor tag.");
+
+                    default:
+                    {
+                        /* TODO: Should we handle other optional descriptor tags?
+                         *  ExtensionDescriptor extDescr[0 .. 255];
+                         LanguageDescriptor langDescr[0 .. 1];
+                         IPI_DescPointer ipiPtr[0 .. 1];
+                         IP_IdentificationDataSet ipIDS[0 .. 1];
+                         QoS_Descriptor qosDescr[0 .. 1];
+                        */
+                        uint length = ReadLength(box_data, ref offset); // Every descriptor starts with a length
+
+                        offset += (int)length; // Skip the rest of the descriptor as reported in the length so we can move onto the next one
+                        break;
+                    }
+                }
+            }
         }
 
 #endregion
@@ -148,7 +358,10 @@ namespace TagLib.Mpeg4
         ///    A <see cref="ushort" /> value containing the ID of the
         ///    stream described by the current instance.
         /// </value>
-        public ushort StreamId { get; private set; }
+        public ushort StreamId
+        {
+            get { return es_id; }
+        }
 
         /// <summary>
         ///    Gets the priority of the stream described by the current
@@ -158,7 +371,10 @@ namespace TagLib.Mpeg4
         ///    A <see cref="byte" /> value containing the priority of
         ///    the stream described by the current instance.
         /// </value>
-        public byte StreamPriority { get; private set; }
+        public byte StreamPriority
+        {
+            get { return stream_priority; }
+        }
 
         /// <summary>
         ///    Gets the object type ID of the stream described by the
@@ -168,7 +384,10 @@ namespace TagLib.Mpeg4
         ///    A <see cref="byte" /> value containing the object type ID
         ///    of the stream described by the current instance.
         /// </value>
-        public byte ObjectTypeId { get; private set; }
+        public byte ObjectTypeId
+        {
+            get { return object_type_id; }
+        }
 
         /// <summary>
         ///    Gets the type the stream described by the current
@@ -178,7 +397,10 @@ namespace TagLib.Mpeg4
         ///    A <see cref="byte" /> value containing the type the
         ///    stream described by the current instance.
         /// </value>
-        public byte StreamType { get; private set; }
+        public byte StreamType
+        {
+            get { return stream_type; }
+        }
 
         /// <summary>
         ///    Gets the buffer size DB value the stream described by the
@@ -188,7 +410,10 @@ namespace TagLib.Mpeg4
         ///    A <see cref="uint" /> value containing the buffer size DB
         ///    value the stream described by the current instance.
         /// </value>
-        public uint BufferSizeDB { get; private set; }
+        public uint BufferSizeDB
+        {
+            get { return buffer_size_db; }
+        }
 
         /// <summary>
         ///    Gets the maximum bitrate the stream described by the
@@ -198,9 +423,7 @@ namespace TagLib.Mpeg4
         ///    A <see cref="uint" /> value containing the maximum
         ///    bitrate the stream described by the current instance.
         /// </value>
-        public uint MaximumBitrate {
-            get { return max_bitrate / 1000; }
-        }
+        public uint MaximumBitrate { get { return max_bitrate / 1000; } }
 
         /// <summary>
         ///    Gets the maximum average the stream described by the
@@ -210,9 +433,7 @@ namespace TagLib.Mpeg4
         ///    A <see cref="uint" /> value containing the average
         ///    bitrate the stream described by the current instance.
         /// </value>
-        public uint AverageBitrate {
-            get { return average_bitrate / 1000; }
-        }
+        public uint AverageBitrate { get { return average_bitrate / 1000; } }
 
         /// <summary>
         ///    Gets the decoder config data of stream described by the
@@ -223,7 +444,7 @@ namespace TagLib.Mpeg4
         ///    config data of the stream described by the current
         ///    instance.
         /// </value>
-        public ByteVector DecoderConfig { get; private set; }
+        public ByteVector DecoderConfig { get { return decoder_config; } }
 
 #endregion
 
@@ -247,16 +468,17 @@ namespace TagLib.Mpeg4
         ///    A <see cref="uint" /> value containing the length that
         ///    was read.
         /// </returns>
-        static uint ReadLength (ByteVector data, ref int offset)
+        private static uint ReadLength(ByteVector data, ref int offset)
         {
             byte b;
             int end = offset + 4;
             uint length = 0;
 
-            do {
+            do
+            {
                 b = data[offset++];
-                length = length << 7 | (uint)(b & 0x7f);
-            } while ((b & 0x80) != 0 && offset <= end);
+                length = (uint)(length << 7) | (uint)(b & 0x7f);
+            } while ((b & 0x80) != 0 && offset <= end); // The Length could be between 1 and 4 bytes for each descriptor
 
             return length;
         }

--- a/src/TaglibSharp/Mpeg4/Boxes/AppleElementaryStreamDescriptor.cs
+++ b/src/TaglibSharp/Mpeg4/Boxes/AppleElementaryStreamDescriptor.cs
@@ -423,7 +423,10 @@ namespace TagLib.Mpeg4
         ///    A <see cref="uint" /> value containing the maximum
         ///    bitrate the stream described by the current instance.
         /// </value>
-        public uint MaximumBitrate { get { return max_bitrate / 1000; } }
+        public uint MaximumBitrate
+        {
+            get { return max_bitrate / 1000; }
+        }
 
         /// <summary>
         ///    Gets the maximum average the stream described by the
@@ -433,7 +436,10 @@ namespace TagLib.Mpeg4
         ///    A <see cref="uint" /> value containing the average
         ///    bitrate the stream described by the current instance.
         /// </value>
-        public uint AverageBitrate { get { return average_bitrate / 1000; } }
+        public uint AverageBitrate
+        {
+            get { return average_bitrate / 1000; }
+        }
 
         /// <summary>
         ///    Gets the decoder config data of stream described by the
@@ -444,7 +450,10 @@ namespace TagLib.Mpeg4
         ///    config data of the stream described by the current
         ///    instance.
         /// </value>
-        public ByteVector DecoderConfig { get { return decoder_config; } }
+        public ByteVector DecoderConfig
+        {
+            get { return decoder_config; }
+        }
 
 #endregion
 


### PR DESCRIPTION
Read and parse Apple Elementary Stream Descriptor (ESDS) atoms including embedded descriptors

See https://github.com/mono/taglib-sharp/pull/147